### PR TITLE
RA-40 Add caching for recipe list

### DIFF
--- a/app/src/main/java/com/mrt/androidrecipesapp/data/AppDatabase.kt
+++ b/app/src/main/java/com/mrt/androidrecipesapp/data/AppDatabase.kt
@@ -6,7 +6,7 @@ import androidx.room.TypeConverters
 import com.mrt.androidrecipesapp.model.Category
 import com.mrt.androidrecipesapp.model.Recipe
 
-@Database(entities = [Category::class, Recipe::class], version = 2, exportSchema = false)
+@Database(entities = [Category::class, Recipe::class], version = 3, exportSchema = false)
 @TypeConverters(Converters::class)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun categoriesDao(): CategoriesDao

--- a/app/src/main/java/com/mrt/androidrecipesapp/data/AppDatabase.kt
+++ b/app/src/main/java/com/mrt/androidrecipesapp/data/AppDatabase.kt
@@ -2,9 +2,14 @@ package com.mrt.androidrecipesapp.data
 
 import androidx.room.Database
 import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
 import com.mrt.androidrecipesapp.model.Category
+import com.mrt.androidrecipesapp.model.Recipe
 
-@Database(entities = [Category::class], version = 1, exportSchema = false)
+@Database(entities = [Category::class, Recipe::class], version = 2, exportSchema = false)
+@TypeConverters(Converters::class)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun categoriesDao(): CategoriesDao
+
+    abstract fun recipesListDao(): RecipesListDao
 }

--- a/app/src/main/java/com/mrt/androidrecipesapp/data/Converters.kt
+++ b/app/src/main/java/com/mrt/androidrecipesapp/data/Converters.kt
@@ -1,0 +1,27 @@
+package com.mrt.androidrecipesapp.data
+
+import androidx.room.TypeConverter
+import com.google.gson.Gson
+import com.mrt.androidrecipesapp.model.Ingredient
+
+class Converters {
+    @TypeConverter
+    fun fromIngredientsList(ingredients: List<Ingredient>): String {
+        return Gson().toJson(ingredients)
+    }
+
+    @TypeConverter
+    fun toIngredientsList(data: String): List<Ingredient> {
+        return Gson().fromJson(data, Array<Ingredient>::class.java).toList()
+    }
+
+    @TypeConverter
+    fun fromMethodList(method: List<String>): String {
+        return Gson().toJson(method)
+    }
+
+    @TypeConverter
+    fun toMethodList(data: String): List<String> {
+        return Gson().fromJson(data, Array<String>::class.java).toList()
+    }
+}

--- a/app/src/main/java/com/mrt/androidrecipesapp/data/RecipesListDao.kt
+++ b/app/src/main/java/com/mrt/androidrecipesapp/data/RecipesListDao.kt
@@ -11,6 +11,9 @@ interface RecipesListDao {
     @Query("SELECT * FROM recipe")
     fun getAllRecipes(): List<Recipe>
 
+    @Query("SELECT * FROM recipe WHERE categoryId = :categoryId")
+    fun getRecipesByCategory(categoryId: Int): List<Recipe>
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun addRecipe(recipes: List<Recipe>)
 }

--- a/app/src/main/java/com/mrt/androidrecipesapp/data/RecipesListDao.kt
+++ b/app/src/main/java/com/mrt/androidrecipesapp/data/RecipesListDao.kt
@@ -1,0 +1,16 @@
+package com.mrt.androidrecipesapp.data
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.mrt.androidrecipesapp.model.Recipe
+
+@Dao
+interface RecipesListDao {
+    @Query("SELECT * FROM recipe")
+    fun getAllRecipes(): List<Recipe>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    fun addRecipe(recipes: List<Recipe>)
+}

--- a/app/src/main/java/com/mrt/androidrecipesapp/data/RecipesRepository.kt
+++ b/app/src/main/java/com/mrt/androidrecipesapp/data/RecipesRepository.kt
@@ -60,14 +60,15 @@ class RecipesRepository(application: Application) {
 
     private val recipesListDao: RecipesListDao = db.recipesListDao()
 
-    suspend fun getRecipesListFromCache(): List<Recipe> =
+    suspend fun getRecipesListFromCache(categoryId: Int): List<Recipe> =
         withContext(defaultDispatcher) {
-            recipesListDao.getAllRecipes()
+            recipesListDao.getRecipesByCategory(categoryId)
         }
 
-    suspend fun addRecipesToCache(recipes: List<Recipe>) =
+    suspend fun addRecipesToCache(recipes: List<Recipe>, categoryId: Int) =
         withContext(defaultDispatcher) {
-            recipesListDao.addRecipe(recipes)
+            val updatedRecipes = recipes.map { it.copy(categoryId = categoryId) }
+            recipesListDao.addRecipe(updatedRecipes)
         }
 
     suspend fun getCategories(): List<Category>? =

--- a/app/src/main/java/com/mrt/androidrecipesapp/data/RecipesRepository.kt
+++ b/app/src/main/java/com/mrt/androidrecipesapp/data/RecipesRepository.kt
@@ -41,8 +41,10 @@ class RecipesRepository(application: Application) {
     private val db: AppDatabase = Room.databaseBuilder(
         application.applicationContext,
         AppDatabase::class.java,
-        "database-categories"
-    ).build()
+        "database"
+    )
+        .fallbackToDestructiveMigration()
+        .build()
 
     private val categoriesDao: CategoriesDao = db.categoriesDao()
 
@@ -54,6 +56,18 @@ class RecipesRepository(application: Application) {
     suspend fun addCategoryToCache(categories: List<Category>) =
         withContext(defaultDispatcher) {
             categoriesDao.addCategory(categories)
+        }
+
+    private val recipesListDao: RecipesListDao = db.recipesListDao()
+
+    suspend fun getRecipesListFromCache(): List<Recipe> =
+        withContext(defaultDispatcher) {
+            recipesListDao.getAllRecipes()
+        }
+
+    suspend fun addRecipesToCache(recipes: List<Recipe>) =
+        withContext(defaultDispatcher) {
+            recipesListDao.addRecipe(recipes)
         }
 
     suspend fun getCategories(): List<Category>? =

--- a/app/src/main/java/com/mrt/androidrecipesapp/model/Ingredient.kt
+++ b/app/src/main/java/com/mrt/androidrecipesapp/model/Ingredient.kt
@@ -1,13 +1,17 @@
 package com.mrt.androidrecipesapp.model
 
 import android.os.Parcelable
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
 import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.Serializable
 
 @Parcelize
 @Serializable
+@Entity
 data class Ingredient(
-    val quantity: String,
-    val unitOfMeasure: String,
-    val description: String,
+    @PrimaryKey val quantity: String,
+    @ColumnInfo(name = "unitOfMeasure") val unitOfMeasure: String,
+    @ColumnInfo(name = "description") val description: String,
 ) : Parcelable

--- a/app/src/main/java/com/mrt/androidrecipesapp/model/Recipe.kt
+++ b/app/src/main/java/com/mrt/androidrecipesapp/model/Recipe.kt
@@ -1,15 +1,19 @@
 package com.mrt.androidrecipesapp.model
 
 import android.os.Parcelable
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
 import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.Serializable
 
 @Parcelize
 @Serializable
+@Entity
 data class Recipe(
-    val id: Int,
-    val title: String,
-    val ingredients: List<Ingredient>,
-    val method: List<String>,
-    val imageUrl: String,
+    @PrimaryKey val id: Int,
+    @ColumnInfo(name = "title") val title: String,
+    @ColumnInfo(name = "ingredients") val ingredients: List<Ingredient> = emptyList(),
+    @ColumnInfo(name = "method") val method: List<String> = emptyList(),
+    @ColumnInfo(name = "imageUrl") val imageUrl: String,
 ) : Parcelable

--- a/app/src/main/java/com/mrt/androidrecipesapp/model/Recipe.kt
+++ b/app/src/main/java/com/mrt/androidrecipesapp/model/Recipe.kt
@@ -16,4 +16,5 @@ data class Recipe(
     @ColumnInfo(name = "ingredients") val ingredients: List<Ingredient> = emptyList(),
     @ColumnInfo(name = "method") val method: List<String> = emptyList(),
     @ColumnInfo(name = "imageUrl") val imageUrl: String,
+    @ColumnInfo(name = "categoryId") @Transient val categoryId: Int = -1,
 ) : Parcelable

--- a/app/src/main/java/com/mrt/androidrecipesapp/ui/recipes/recipes_list/RecipesListViewModel.kt
+++ b/app/src/main/java/com/mrt/androidrecipesapp/ui/recipes/recipes_list/RecipesListViewModel.kt
@@ -32,7 +32,7 @@ class RecipesListViewModel(private val application: Application) :
     fun loadRecipesList(categoryId: Int) {
         viewModelScope.launch {
             try {
-                val recipesFromCache = recipesRepository.getRecipesListFromCache()
+                val recipesFromCache = recipesRepository.getRecipesListFromCache(categoryId)
                 _state.postValue(
                     _state.value?.copy(
                         recipes = recipesFromCache
@@ -40,7 +40,12 @@ class RecipesListViewModel(private val application: Application) :
                 )
 
                 val recipes = recipesRepository.getRecipesByCategoryId(categoryId)
-                recipesRepository.addRecipesToCache(recipes ?: emptyList())
+                recipesRepository.addRecipesToCache(recipes ?: emptyList(), categoryId)
+                _state.postValue(
+                    _state.value?.copy(
+                        recipes = recipes
+                    )
+                )
 
             } catch (e: Exception) {
                 Log.e("!!!", "Ошибка загрузки категорий", e)

--- a/app/src/main/java/com/mrt/androidrecipesapp/ui/recipes/recipes_list/RecipesListViewModel.kt
+++ b/app/src/main/java/com/mrt/androidrecipesapp/ui/recipes/recipes_list/RecipesListViewModel.kt
@@ -32,12 +32,16 @@ class RecipesListViewModel(private val application: Application) :
     fun loadRecipesList(categoryId: Int) {
         viewModelScope.launch {
             try {
-                val recipes = recipesRepository.getRecipesByCategoryId(categoryId)
+                val recipesFromCache = recipesRepository.getRecipesListFromCache()
                 _state.postValue(
                     _state.value?.copy(
-                        recipes = recipes
-                    ) ?: RecipesListState(recipes = recipes)
+                        recipes = recipesFromCache
+                    )
                 )
+
+                val recipes = recipesRepository.getRecipesByCategoryId(categoryId)
+                recipesRepository.addRecipesToCache(recipes ?: emptyList())
+
             } catch (e: Exception) {
                 Log.e("!!!", "Ошибка загрузки категорий", e)
                 Toast.makeText(application, "Ошибка получения данных", Toast.LENGTH_SHORT).show()
@@ -58,6 +62,7 @@ class RecipesListViewModel(private val application: Application) :
                         categoryImage = "${BASE_URL}images/${category?.imageUrl}"
                     )
                 )
+                Log.i("!!!", "state.value?.currentCategory - ${state.value?.currentCategory}")
             } catch (e: Exception) {
                 Log.e("!!!", "Ошибка загрузки категории", e)
                 Toast.makeText(application, "Ошибка получения данных", Toast.LENGTH_SHORT).show()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,5 +4,5 @@ plugins {
     alias(libs.plugins.jetbrains.kotlin.android) apply false
     id("androidx.navigation.safeargs.kotlin") version "2.8.6" apply false
     kotlin("plugin.serialization") version "2.1.0"
-    id("com.google.devtools.ksp") version "2.0.0-1.0.23" apply false
+    id("com.google.devtools.ksp") version "2.1.10-1.0.29" apply false
 }


### PR DESCRIPTION
Опять сложности)
Мы получается загружаем экран со списком товаров по ID категории. Если в API у нас товары связаны с категории относительно get параметров, то при добавлении товаров в базу такая привязка теряется. И получается, что в кеш просто попадают все рецепты и потом во всех категориях показываются также все рецепты.
Тут как бы по логике напрашивает в класс Recipe добавить поле categoryId. Но мы же вроде не должны переписывать этот код?
Или в базе как-то добавлять к рецептам это поле?
Как быть?